### PR TITLE
fix RT 77966: force comparison to use string context

### DIFF
--- a/lib/Test/LongString.pm
+++ b/lib/Test/LongString.pm
@@ -62,7 +62,7 @@ sub _display {
 
 sub _common_prefix_length {
     my ($str1, $str2) = @_;
-    my $diff = $str1 ^ $str2;
+    my $diff = "$str1" ^ "$str2";
     my ($pre) = $diff =~ /^(\000*)/;
     return length $pre;
 }

--- a/t/01teststring.t
+++ b/t/01teststring.t
@@ -2,7 +2,7 @@
 
 use strict;
 
-use Test::More tests => 11;
+use Test::More tests => 15;
 use Test::Builder::Tester;
 use Test::Builder::Tester::Color;
 
@@ -122,3 +122,44 @@ test_diag(qq(after whitespace removal:
 #     strings begin to differ at char 3));
 is_string_nows("a b c", "abd", "non-ws differs");
 test_test("is_string_nows tests correctly");
+
+test_out("not ok 1 - 123 is 124");
+test_fail(6);
+test_diag(qq!         got: "123"
+#       length: 3
+#     expected: "124"
+#       length: 3
+#     strings begin to differ at char 3 (line 1 column 3)!);
+is_string("123", "124", "123 is 124");
+test_test("two short number strings differ at char 3");
+
+test_out("not ok 1 - 123 is 124");
+test_fail(6);
+test_diag(qq!         got: "123"
+#       length: 3
+#     expected: "124"
+#       length: 3
+#     strings begin to differ at char 3 (line 1 column 3)!);
+is_string(0+"123", 0+"124", "123 is 124");
+test_test("two small numbers compared in string context differ at char 3");
+
+test_out("not ok 1 - 123 is 123xyz");
+test_fail(6);
+test_diag(qq!         got: "123"
+#       length: 3
+#     expected: "123xyz"
+#       length: 6
+#     strings begin to differ at char 4 (line 1 column 4)!);
+is_string("123", "123xyz", "123 is 123xyz");
+test_test("short number string differs from short string at char 4");
+
+test_out("not ok 1 - 123 is 123xyz");
+test_fail(6);
+test_diag(qq!         got: "123"
+#       length: 3
+#     expected: "123xyz"
+#       length: 6
+#     strings begin to differ at char 4 (line 1 column 4)!);
+is_string(0+"123", "123xyz", "123 is 123xyz");
+test_test("small number differs from short string at char 4");
+


### PR DESCRIPTION
In reference to https://rt.cpan.org/Public/Bug/Display.html?id=77966 .

Test::LongString now shows at which character two numbers first differ, by forcing string context when  calculating $diff in sub _common_prefix_length.
